### PR TITLE
Handle edge case where dict versions can disagree on index

### DIFF
--- a/draft-ietf-tls-cert-abridge.md
+++ b/draft-ietf-tls-cert-abridge.md
@@ -191,8 +191,9 @@ The algorithm for enumerating the list of compressible intermediate and root cer
 4. Remove all root certificates which are not marked as trusted or in the process of applying to be trusted by at least one of the following browser root programs: Mozilla, Google, Microsoft, Apple.
 5. Remove all intermediate certificates which are not signed by root certificates still in the listing.
 6. Remove any certificates which are duplicates (have the same SHA256 certificate fingerprint)
-7. Order the list by the date each certificate was included in the CCADB, breaking ties with the lexicographic ordering of the SHA256 certificate fingerprint.
-8. Associate each element of the list with the concatenation of the constant `0xff` and its index in the list represented as a `uint16`.
+7. Remove all certificates which were first included in the CCADB on the date of `CCADB_SNAPSHOT_TIME`.
+8. Order the list by the date each certificate was included in the CCADB, breaking ties with the lexicographic ordering of the SHA256 certificate fingerprint.
+9. Associate each element of the list with the concatenation of the constant `0xff` and its index in the list represented as a `uint16`.
 
 [[**DISCUSS:** The four programs were selected because they represent certificate consumers in the CCADB. Are there any other root programs which ought to be included? The only drawback is a larger disk requirement, since this compression scheme does not impact trust decisions.]]
 


### PR DESCRIPTION
Reading step 7 "Order the list by the date each certificate was included in the CCADB, breaking ties with the lexicographic ordering of the SHA256 certificate fingerprint." along with some of the later assumptions on newer versions of the dictionary agreeing on existing keys, I believe there's an edge case where a snapshot occurs during a day in which multiple entries are added to CCADB. I am picturing a scenario where two CAs are added on a snapshot date (one before and one after a snapshot where the latter has a digest lexicographically preceding the former). In this scenario, future snapshots would have a different list index than the older snapshot from the addition date, causing verification failure after decompression. I've added an additional condition that should avoid this edge case at a minimal cost that still preserves the rest of the algorithm.